### PR TITLE
Add mocha setup and convert.js test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
     "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "chai": "^4.3.10"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+const {expect} = require('chai');
+
+describe('convert.js', function() {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+  const publicDir = path.join(tmpDir, 'public');
+  const txtFile = path.join(publicDir, 'bannedlist.txt');
+  const jsonFile = path.join(publicDir, 'bannedlist.json');
+  const convertSource = path.join(__dirname, '..', 'convert.js');
+  const convertCopy = path.join(tmpDir, 'convert.js');
+
+  before(function() {
+    fs.mkdirSync(publicDir, {recursive: true});
+    fs.writeFileSync(txtFile, 'foo\nbar');
+    fs.copyFileSync(convertSource, convertCopy);
+    execFileSync('node', [convertCopy], {cwd: tmpDir});
+  });
+
+  after(function() {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('creates bannedlist.json with bannedWords array', function() {
+    const content = fs.readFileSync(jsonFile, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed).to.be.an('object');
+    expect(parsed).to.have.property('bannedWords');
+    expect(parsed.bannedWords).to.be.an('array');
+  });
+});


### PR DESCRIPTION
## Summary
- install mocha and chai as dev dependencies
- add test script
- add tests to confirm bannedlist.json structure

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402e2479a48333839551b1cf6ce1d4