### PR TITLE
Fix loadDenominations typo

### DIFF
--- a/public/profile/script.js
+++ b/public/profile/script.js
@@ -271,7 +271,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const response = await fetch('../denominations.json'); // Ensure the correct path to the JSON file
       const data = await response.json();
-      const denominations = data.dominations;
+      const denominations = data.denominations;
       const editDenominationSelect = document.getElementById('editDenomination');
 
       denominations.forEach(denomination => {


### PR DESCRIPTION
## Summary
- fix typo in profile script when loading denominations

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402e1401e483338cfdffb06bc6af43